### PR TITLE
Fix Linux package check not working for non-apt-based distros

### DIFF
--- a/Scripts/Main/Packages_Location/FFmpeg.pyw
+++ b/Scripts/Main/Packages_Location/FFmpeg.pyw
@@ -17,7 +17,7 @@ if system() == "Windows":
 		)
 else:
 	try:
-		if cache[__FFmpeg.lower()].is_installed:
+		if is_package_installed.get(__FFmpeg.lower()):
 			__FFmpeg = __FFmpeg.lower()
 	except IndexError:
 		print(__FFmpeg_Error_1 + ' {1}("{0}"){2}'.format(

--- a/Scripts/Main/Packages_Location/Gifsicle.pyw
+++ b/Scripts/Main/Packages_Location/Gifsicle.pyw
@@ -17,7 +17,7 @@ if system() == "Windows":
 		)
 else:
 	try:
-		if cache[__GifSicle.lower()].is_installed:
+		if is_package_installed.get(__GifSicle.lower()):
 			__GifSicle = __GifSicle.lower()
 	except IndexError:
 		print(__GifSicle_Error_1 + ' {1}("{0}"){2}'.format(

--- a/Scripts/Main/Packages_Location/OxiPNG.pyw
+++ b/Scripts/Main/Packages_Location/OxiPNG.pyw
@@ -17,7 +17,7 @@ if system() == "Windows":
 		)
 else:
 	try:
-		if cache[__OxiPNG.lower()].is_installed:
+		if is_package_installed.get(__OxiPNG.lower()):
 			__OxiPNG = __OxiPNG.lower()
 	except IndexError:
 		print(__OxiPNG_Error_1 + ' {1}("{0}"){2}'.format(

--- a/Scripts/Main/Packages_Location/PNGQuant.pyw
+++ b/Scripts/Main/Packages_Location/PNGQuant.pyw
@@ -17,7 +17,7 @@ if system() == "Windows":
 		)
 else:
 	try:
-		if cache[__PNGQuant.lower()].is_installed:
+		if is_package_installed.get(__PNGQuant.lower()):
 			__PNGQuant = __PNGQuant.lower()
 	except IndexError:
 		print(__PNGQuant_Error_1 + ' {1}("{0}"){2}'.format(

--- a/iFunny_Captions.pyw
+++ b/iFunny_Captions.pyw
@@ -29,7 +29,7 @@ from unidecode import unidecode as normalize
 from argparse import ArgumentParser as ap, SUPPRESS
 from emoji import emojize, demojize, UNICODE_EMOJI_ENGLISH
 from tkinter import Tk, filedialog as fd, messagebox as msgbox
-from shutil import copyfile, move as mv, rmtree, unpack_archive
+from shutil import copyfile, move as mv, rmtree, unpack_archive, which
 from PIL import Image, ImageChops, ImageColor as IC, ImageDraw, ImageFile, ImageFont, ImageOps, PngImagePlugin, UnidentifiedImageError
 
 #-------------------------#
@@ -84,8 +84,12 @@ exec(open_("Error_Handler"))
 
 # Getting Packages Location
 if not system() == "Windows":
-	import apt
-	cache = apt.Cache()
+	is_package_installed = {
+		"ffmpeg": which("ffmpeg") is not None,
+		"gifsicle": which("gifsicle") is not None,
+		"oxipng": which("oxipng") is not None,
+		"pngquant": which("pngquant") is not None,
+	}
 
 exec(open_("Packages_Location/FFmpeg"))
 exec(open_("Folder/Name"))


### PR DESCRIPTION
Hi, I noticed you were updating the original GIF caption maker repo, so I figured I'd help out.

On non-APT-based Linux distros, the main script fails at `import apt` as these distros use different package managers.
I replaced this check with `shutil.which`, natively supported by Python, which simply checks if each executable is on the system PATH.

Tested and working on EndeavourOS.